### PR TITLE
Use arbitrary match for file names

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -23,17 +23,9 @@ GCC_OPTS=" -Wall -O2 -nostartfiles -nostdlib -mhard-float -ffreestanding -mcpu=a
 
 COMPILE="arm-none-eabi-gcc $GCC_OPTS"
 
-mkdir -p OBJ
+mkdir -p SOBJ
 
-$COMPILE -o OBJ/CirnOS.elf -T SRC/loader SRC/vectors.s SRC/main.c\
-	 SRC/hdmi.c SRC/bcm2835.c SRC/syscalls.c SRC/emmc.c SRC/ff.c SRC/diskio.c SRC/ffunicode.c SRC/luabcm.c\
-	 SRC/LUA/lapi.c SRC/LUA/lbaselib.c SRC/LUA/lauxlib.c SRC/LUA/lbitlib.c SRC/LUA/lcode.c\
-	 SRC/LUA/lcorolib.c SRC/LUA/lctype.c SRC/LUA/ldblib.c SRC/LUA/ldebug.c SRC/LUA/ldo.c\
-	 SRC/LUA/ldump.c SRC/LUA/lfunc.c SRC/LUA/lgc.c SRC/LUA/linit.c SRC/LUA/liolib.c SRC/LUA/llex.c\
-	 SRC/LUA/lmathlib.c SRC/LUA/lmem.c SRC/LUA/loadlib.c SRC/LUA/lobject.c SRC/LUA/lopcodes.c SRC/LUA/loslib.c\
-	 SRC/LUA/lparser.c SRC/LUA/lstate.c SRC/LUA/lstring.c SRC/LUA/lstrlib.c SRC/LUA/ltable.c\
-	 SRC/LUA/ltablib.c SRC/LUA/ltm.c SRC/LUA/lundump.c SRC/LUA/lutf8lib.c SRC/LUA/lvm.c SRC/LUA/lzio.c\
-	 -L/usr/lib/arm-none-eabi/newlib/hard -lc -lgcc -lnosys -lm
+$COMPILE -o SOBJ/CirnOS.elf -T SRC/loader SRC/vectors.s SRC/*.c SRC/LUA/*.c  -L/usr/lib/arm-none-eabi/newlib/hard -lc -lgcc -lnosys -lm
 
 # extract binary image from ELF executable
-arm-none-eabi-objcopy OBJ/CirnOS.elf -O binary OBJ/kernel.img
+arm-none-eabi-objcopy SOBJ/CirnOS.elf -O binary SOBJ/kernel.img


### PR DESCRIPTION
I just edited the build.sh so that there wont be any need of listing the C file names . I also removed luac.c which is the entry point for lua files. I noticed that it was not originally used in your code, and I found that because I am using arbitrary match it is being compiled which triggers error message because it has "main" function.

Clean up syscalls.c file